### PR TITLE
Add support for ranges in glob patterns

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/mattn/go-zglob"
+	"github.com/oalders/go-zglob"
 	"github.com/pkg/errors"
 )
 

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -53,11 +53,15 @@ func Paths(config *Precious) (bool, error) {
 	return success, nil
 }
 
-func patternsOk(seen matchCache, ppath *Ppath, commandName, section string, patterns []string) (bool, error) {
+func patternsOk(
+	seen matchCache,
+	ppath *Ppath,
+	commandName, section string,
+	patterns []string,
+) (bool, error) {
 	success := true
 	for _, pattern := range patterns {
 		matched, exists := seen[pattern]
-
 		if exists && matched {
 			continue
 		}
@@ -65,6 +69,7 @@ func patternsOk(seen matchCache, ppath *Ppath, commandName, section string, patt
 		// For our purposes found and ignored are the same thing.
 		if patternIgnored(ppath, commandName, pattern) {
 			seen[pattern] = true
+
 			continue
 		}
 
@@ -82,6 +87,7 @@ func patternsOk(seen matchCache, ppath *Ppath, commandName, section string, patt
 				}
 			} else if len(matches) > 0 {
 				seen[pattern] = true
+
 				continue
 			}
 		}

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -18,6 +18,7 @@ func init() {
 }
 
 func TestPaths(t *testing.T) {
+	t.Parallel()
 	config, err := PreciousConfig("testdata/precious.toml")
 	assert.NoError(t, err)
 	success, err := Paths(config)
@@ -26,6 +27,7 @@ func TestPaths(t *testing.T) {
 }
 
 func TestPathsFailure(t *testing.T) {
+	t.Parallel()
 	config, err := PreciousConfig("testdata/precious-fail.toml")
 	assert.NoError(t, err)
 	success, err := Paths(config)
@@ -34,6 +36,7 @@ func TestPathsFailure(t *testing.T) {
 }
 
 func TestPatternsOkFailure(t *testing.T) {
+	t.Parallel()
 	ignoreConfig, err := PpathConfig(".ppath.toml")
 	assert.NoError(t, err)
 
@@ -50,6 +53,7 @@ func TestPatternsOkFailure(t *testing.T) {
 }
 
 func TestPatternsOkSuccess(t *testing.T) {
+	t.Parallel()
 	ignoreConfig, err := PpathConfig(".ppath.toml")
 	assert.NoError(t, err)
 
@@ -70,6 +74,7 @@ func TestPatternsOkSuccess(t *testing.T) {
 }
 
 func TestPatternIgnored(t *testing.T) {
+	t.Parallel()
 	ignoreConfig, err := PpathConfig(".ppath.toml")
 	assert.NoError(t, err)
 

--- a/audit/config.go
+++ b/audit/config.go
@@ -25,6 +25,7 @@ func PpathConfig(filename string) (*Ppath, error) {
 		if os.IsNotExist(err) {
 			return &config, nil
 		}
+
 		return nil, errors.Wrapf(err, "cannot stat %s", filename)
 	}
 	dat, err := os.ReadFile(filename)

--- a/audit/config.go
+++ b/audit/config.go
@@ -37,7 +37,7 @@ func PpathConfig(filename string) (*Ppath, error) {
 		)
 	}
 	if err := toml.Unmarshal(dat, &config); err != nil {
-		errors.Wrapf(err, "unmarshal toml in %s", filename)
+		return nil, errors.Wrapf(err, "unmarshal toml in %s", filename)
 	}
 
 	return &config, nil
@@ -56,7 +56,7 @@ func PreciousConfig(filename string) (*Precious, error) {
 	}
 	var config Precious
 	if err := toml.Unmarshal(dat, &config); err != nil {
-		errors.Wrapf(err, "unmarshal toml in %s", filename)
+		return nil, errors.Wrapf(err, "unmarshal toml in %s", filename)
 	}
 
 	return &config, nil

--- a/audit/config_test.go
+++ b/audit/config_test.go
@@ -18,6 +18,7 @@ func init() {
 }
 
 func TestPpathConfigDoesNotExist(t *testing.T) {
+	t.Parallel()
 	c, err := PpathConfig("testdata/.noppath.toml")
 	assert.NoError(t, err)
 
@@ -31,6 +32,7 @@ func TestPpathConfigDoesNotExist(t *testing.T) {
 }
 
 func TestPpathConfig(t *testing.T) {
+	t.Parallel()
 	c, err := PpathConfig("testdata/.ppath.toml")
 	assert.NoError(t, err)
 
@@ -43,12 +45,14 @@ func TestPpathConfig(t *testing.T) {
 }
 
 func TestPreciousConfigDoesNotExist(t *testing.T) {
+	t.Parallel()
 	c, err := PreciousConfig("testdata/precious-not-found.toml")
 	assert.Error(t, err)
 	assert.Empty(t, c)
 }
 
 func TestPreciousFailConfig(t *testing.T) {
+	t.Parallel()
 	c, err := PreciousConfig("testdata/precious-fail.toml")
 	assert.NoError(t, err)
 
@@ -70,6 +74,7 @@ func TestPreciousFailConfig(t *testing.T) {
 }
 
 func TestPreciousSuccessConfig(t *testing.T) {
+	t.Parallel()
 	c, err := PreciousConfig("testdata/precious.toml")
 	assert.NoError(t, err)
 

--- a/audit/config_test.go
+++ b/audit/config_test.go
@@ -19,28 +19,28 @@ func init() {
 
 func TestPpathConfigDoesNotExist(t *testing.T) {
 	t.Parallel()
-	c, err := PpathConfig("testdata/.noppath.toml")
+	config, err := PpathConfig("testdata/.noppath.toml")
 	assert.NoError(t, err)
 
 	var empty []string
-	assert.Equal(t, empty, c.Ignore)
+	assert.Equal(t, empty, config.Ignore)
 	assert.Equal(
 		t,
 		empty,
-		c.Commands["omegasort-gitignore"].Ignore,
+		config.Commands["omegasort-gitignore"].Ignore,
 	)
 }
 
 func TestPpathConfig(t *testing.T) {
 	t.Parallel()
-	c, err := PpathConfig("testdata/.ppath.toml")
+	config, err := PpathConfig("testdata/.ppath.toml")
 	assert.NoError(t, err)
 
-	assert.Equal(t, []string{`**/node_modules/**/*`}, c.Ignore)
+	assert.Equal(t, []string{`**/node_modules/**/*`}, config.Ignore)
 	assert.Equal(
 		t,
 		[]string{`**/foo/**/*`},
-		c.Commands["omegasort-gitignore"].Ignore,
+		config.Commands["omegasort-gitignore"].Ignore,
 	)
 }
 
@@ -53,7 +53,7 @@ func TestPreciousConfigDoesNotExist(t *testing.T) {
 
 func TestPreciousFailConfig(t *testing.T) {
 	t.Parallel()
-	c, err := PreciousConfig("testdata/precious-fail.toml")
+	config, err := PreciousConfig("testdata/precious-fail.toml")
 	assert.NoError(t, err)
 
 	assert.Equal(t,
@@ -61,7 +61,7 @@ func TestPreciousFailConfig(t *testing.T) {
 			Exclude: "baz",
 			Include: `**/.gitignore`,
 		},
-		c.Commands["omegasort-gitignore"],
+		config.Commands["omegasort-gitignore"],
 	)
 
 	assert.Equal(t,
@@ -69,13 +69,13 @@ func TestPreciousFailConfig(t *testing.T) {
 			Exclude: []interface{}{"foo", "bar"},
 			Include: []interface{}{`**/*.go`},
 		},
-		c.Commands["golangci-lint"],
+		config.Commands["golangci-lint"],
 	)
 }
 
 func TestPreciousSuccessConfig(t *testing.T) {
 	t.Parallel()
-	c, err := PreciousConfig("testdata/precious.toml")
+	config, err := PreciousConfig("testdata/precious.toml")
 	assert.NoError(t, err)
 
 	assert.Equal(t,
@@ -83,7 +83,7 @@ func TestPreciousSuccessConfig(t *testing.T) {
 			Exclude: nil,
 			Include: `**/.gitignore`,
 		},
-		c.Commands["omegasort-gitignore"],
+		config.Commands["omegasort-gitignore"],
 	)
 
 	assert.Equal(t,
@@ -91,6 +91,6 @@ func TestPreciousSuccessConfig(t *testing.T) {
 			Exclude: nil,
 			Include: []interface{}{`**/*.go`},
 		},
-		c.Commands["golangci-lint"],
+		config.Commands["golangci-lint"],
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/oalders/ppath
 go 1.19
 
 require (
-	github.com/mattn/go-zglob v0.0.3
+	github.com/oalders/go-zglob v0.0.0-20240710144238-311299660a97
 	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mattn/go-zglob v0.0.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mattn/go-zglob v0.0.3 h1:6Ry4EYsScDyt5di4OI6xw1bYhOqfE5S33Z1OPy+d+To=
 github.com/mattn/go-zglob v0.0.3/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
+github.com/oalders/go-zglob v0.0.0-20240710144238-311299660a97 h1:sMDZzRDiEtWXFWO/CE1ki/8wNt7WRwhkoI8p9MP8Gso=
+github.com/oalders/go-zglob v0.0.0-20240710144238-311299660a97/go.mod h1:KTdypMezlwdwX/YTYe2NnOU8c6cX/eqxFPTcvDfZ7tQ=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
- **Add calls to t.Parallel()**
- **s/c/config/**
- **Add some whitespace due to linter complaints**
- **Fix two errors which were neither checked nor returned**
- **Use a forked go-zglob in order to support ranges in glob patterns**
